### PR TITLE
Flake8 tests are run at the end of pytest session, flake8 result caching is disabled by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.3
+- Flake8 tests are now executed at the end of the test session
+- Flake8 result caching is now disabled by default (re-enable with `--flake8-enable-result-caching`)
+
 ## 1.2.2
 - Added `flake8-cli-arguments` pytest config parameter to pass through pytest cli arguments explicitly
 - Marked `flake8-max-line-length`, `flake8-max-complexity`, `flake8-show-source`, `flake8-statistics`

--- a/pytest-flake8.sublime-project
+++ b/pytest-flake8.sublime-project
@@ -13,12 +13,10 @@
 		}
 	],
 	"configuration":
-	[
-		{
-			"tab_size": 4,
-			"translate_tabs_to_spaces": true,
-			"default_line_ending": "unix",
-			"show_line_endings": true
-		}
-	]
+	{
+		"tab_size": 4,
+		"translate_tabs_to_spaces": true,
+		"default_line_ending": "unix",
+		"show_line_endings": true
+	}
 }

--- a/test/test_pytest_hooks.py
+++ b/test/test_pytest_hooks.py
@@ -1,0 +1,58 @@
+"""Test pytest hook configuration."""
+
+
+def test_pytest_ordering(testdir):
+    """Flake8 tests should be executed at the end of all other tests.
+
+    (Just my personal preference, but, you know, I'm the maintainer.)
+    """
+    testdir.makepyfile(
+        test_pytest_ordering_src="""
+        def test_pass():
+            assert (1 + 1) == 2
+
+        def test_fail():
+            assert 42 is False
+
+        ################### this comment is definetly pep8-incompatible
+
+    """
+    )
+    result = testdir.runpytest("--flake8", "-vv")
+    result.assert_outcomes(passed=1, failed=2)
+    result.stdout.fnmatch_lines(
+        [
+            "*collected 3*",
+            "*::test_pass PASSED*",
+            "*::test_fail FAILED*",
+            "*::FLAKE8 FAILED*",
+        ]
+    )
+
+
+def test_pytest_ordering_early_escape(testdir):
+    """Flake8 tests should be executed at the end of all other tests.
+
+    (Just my personal preference, but, you know, I'm the maintainer.)
+    """
+    testdir.makepyfile(
+        test_pytest_ordering_src="""
+        def test_pass():
+            assert (1 + 1) == 2
+
+        def test_fail():
+            assert 42 is False
+
+        ################### this comment is definetly pep8-incompatible
+
+    """
+    )
+    result = testdir.runpytest("--flake8", "-x", "-vv")
+    result.assert_outcomes(passed=1, failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*collected 3*",
+            "*::test_pass PASSED*",
+            "*::test_fail FAILED*",
+        ]
+    )


### PR DESCRIPTION
idk, I never really understood why we need caching at all. Flake8 is fast enough.