### PR TITLE
don't show the stacktrace on errors

### DIFF
--- a/src/pytest_flake8.py
+++ b/src/pytest_flake8.py
@@ -297,11 +297,6 @@ class Flake8FileCollector(pytest.File):
         (my_key, exp_val) = self.get_cache_item()
         self.flake8_config.flake8_cache.mtimes[my_key] = exp_val
 
-    def repr_failure(self, excinfo):
-        if excinfo.errisinstance(Flake8Error):
-            return excinfo.value.args[0]
-        return super().repr_failure(excinfo)
-
     def collect(self):
         return [
             Flake8Item.from_parent(parent=self, target_path=self.path, name="FLAKE8")
@@ -340,6 +335,11 @@ class Flake8Item(pytest.Item):
             # update mtime only if test passed
             # otherwise failures would not be re-run next time
             self.parent.cache_success()
+
+    def repr_failure(self, excinfo):
+        if excinfo.errisinstance(Flake8Error):
+            return excinfo.value.args[0]
+        return super().repr_failure(excinfo)
 
 
 class Ignorer:

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -232,3 +232,16 @@ def test_junit_classname(testdir, extra_runtest_args):
         j_text = j_file.read()
     result.assert_outcomes(passed=1)
     assert 'classname=""' not in j_text
+
+
+def test_no_stacktrace(testdir, extra_runtest_args):
+    testdir.makefile(
+        ".py",
+        """
+        def f():
+            pass
+    """,
+    )
+    result = testdir.runpytest("--flake8", *extra_runtest_args)
+    result.stdout.no_fnmatch_line("*pytest_flake8.py:*")
+    result.assert_outcomes(failed=1)


### PR DESCRIPTION
overwrites the `repr_failure` method in the right class